### PR TITLE
Removed unused FireGento_DynamicCategory_Model_Rule

### DIFF
--- a/src/app/code/community/FireGento/DynamicCategory/Model/Observer.php
+++ b/src/app/code/community/FireGento/DynamicCategory/Model/Observer.php
@@ -129,8 +129,6 @@ class FireGento_DynamicCategory_Model_Observer
         $request  = $observer->getEvent()->getRequest();
 
         if ($request->getPost('rule')) {
-            /* @var $model FireGento_DynamicCategory_Model_Rule */
-            $model = Mage::getModel('dynamiccategory/rule');
             $data = $request->getPost();
             $data = $this->_filterDates($data, array('from_date', 'to_date'));
 


### PR DESCRIPTION
This model is never use in this method
/\* @var $model FireGento_DynamicCategory_Model_Rule */
$model = Mage::getModel('dynamiccategory/rule');
