### PR TITLE
Fix indexer issues while saving category, fixes #7

### DIFF
--- a/src/app/code/community/FireGento/DynamicCategory/Model/Entity/Attribute/Backend/Rule.php
+++ b/src/app/code/community/FireGento/DynamicCategory/Model/Entity/Attribute/Backend/Rule.php
@@ -59,4 +59,14 @@ class FireGento_DynamicCategory_Model_Entity_Attribute_Backend_Rule
 
         return $this;
     }
+
+
+    public function afterSave($object) {
+        $attrCode = $this->getAttribute()->getAttributeCode();
+
+        //Always update the related products after save.
+        //if ($object->getData($attrCode) != serialize($object->getOrigData($attrCode))) {
+            $object->setIsChangedProductList(true);
+        //}
+    }
 }

--- a/src/app/code/community/FireGento/DynamicCategory/etc/config.xml
+++ b/src/app/code/community/FireGento/DynamicCategory/etc/config.xml
@@ -55,6 +55,11 @@
                 <dynamiccategory>
                     <model>dynamiccategory/indexer_rule</model>
                 </dynamiccategory>
+                <catalog_category_product>
+                    <depends>
+                        <dynamiccategory/>
+                    </depends>
+                </catalog_category_product>
             </indexer>
         </index>
         <resources>


### PR DESCRIPTION
- Make the dynamiccategory index depended on the catalog_category_product index, so that it first adds the dynamic categories.
- After saving a category, mark that the category has changed products to the catalog_category_product indexer is triggered.
