### PR TITLE
Fix the category chooser.

### DIFF
--- a/src/app/design/adminhtml/default/default/template/dynamiccategory/fieldset.phtml
+++ b/src/app/design/adminhtml/default/default/template/dynamiccategory/fieldset.phtml
@@ -37,5 +37,5 @@ $_element = $this->getElement();
 </div>
 
 <script type="text/javascript">
-var <?php echo $_element->getHtmlId() ?> = new VarienRulesForm('<?php echo $_element->getHtmlId() ?>', '<?php echo $this->getNewChildUrl() ?>');
+window.<?php echo $_element->getHtmlId() ?> = new VarienRulesForm('<?php echo $_element->getHtmlId() ?>', '<?php echo $this->getNewChildUrl() ?>');
 </script>


### PR DESCRIPTION
I fixed the category chooser reported in issue #11.
The initialization code of the dynamic category rule is returned in an AJAX response and is executed with eval() by Prototype with a different context, which causes this bug.