### PR TITLE
Model dynamiccategorycron does not exist

### DIFF
--- a/src/app/code/community/FireGento/DynamicCategory/etc/config.xml
+++ b/src/app/code/community/FireGento/DynamicCategory/etc/config.xml
@@ -75,7 +75,7 @@
         <jobs>
             <dynamiccategorycron>
                 <schedule><cron_expr>* 2 * * *</cron_expr></schedule>
-                <run><model>dynamiccategorycron/cron::updateCategories</model></run>
+                <run><model>dynamiccategory/cron::updateCategories</model></run>
             </dynamiccategorycron>
         </jobs>
     </crontab>


### PR DESCRIPTION
The name of the model is wrong and produces an error:

Cron error while executing dynamiccategorycron:

exception 'Mage_Core_Exception' with message 'Invalid callback: dynamiccategorycron/cron::updateCategories does not exist' in ...